### PR TITLE
Change to use id as key for TodoItem

### DIFF
--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -23,7 +23,7 @@ export default class TodoList extends React.Component {
     return <section className="main">
       <ul className="todo-list">
         {this.getItems().map(item =>
-          <TodoItem key={item.get('text')}
+          <TodoItem key={item.get('id')}
                     text={item.get('text')}
                     id={item.get('id')}
                     isCompleted={this.isCompleted(item)}


### PR DESCRIPTION
Otherwise it throws when adding a todo with duplicate text (e.g. a second `React` todo).