### PR TITLE
Simplify Immutable.Map update in doneEditing reducer

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -45,8 +45,7 @@ function doneEditing(state, itemId, newText) {
   const itemIndex = findItemIndex(state, itemId);
   const updatedItem = state.get('todos')
     .get(itemIndex)
-    .set('editing', false)
-    .set('text', newText);
+    .merge({'editing': false, 'text': newText});
 
   return state.update('todos', todos => todos.set(itemIndex, updatedItem));
 }


### PR DESCRIPTION
`Immutable.Map().set().set()` creates two `Map`s, one of them intermediary.
`merge` uses `withMutations` internally to avoid extra work.