### PR TITLE
Fix TextInput autoFocus on double click

### DIFF
--- a/src/components/TextInput.jsx
+++ b/src/components/TextInput.jsx
@@ -34,7 +34,7 @@ export default class TextInput extends React.Component {
                   value={this.state.value}
                   onChange={this._handleOnChange.bind(this)}
                   type="text"
-                  ref="itemInput"
+                  ref={(el) => this.itemInput = el}
                   onKeyDown={this._handleKeyDown.bind(this)}
                   onBlur={this._handleOnBlur.bind(this)}
                   />

--- a/src/components/TodoItem.jsx
+++ b/src/components/TodoItem.jsx
@@ -28,10 +28,10 @@ export default class TodoItem extends React.Component {
         <button className="destroy"
                 onClick={() => this.props.deleteItem(this.props.id)}></button>
       </div>
-      <TextInput text={this.props.text}
+      {this.props.isEditing && <TextInput text={this.props.text}
                  itemId={this.props.id}
                  cancelEditing={this.props.cancelEditing}
-                 doneEditing={this.props.doneEditing} />
+                 doneEditing={this.props.doneEditing} />}
     </li>
   }
 };

--- a/test/components/TextInput_spec.js
+++ b/test/components/TextInput_spec.js
@@ -33,4 +33,16 @@ describe('TextInput', () => {
 
     expect(hasCanceledEditing).to.equal(true);
   });
+  
+  it('should be autofocused when rendered', () => {
+    const text = 'React';
+    
+    const component = renderIntoDocument(
+      <TextInput text={text}/>
+    );
+    
+    const input = component.refs.itemInput;
+    
+    expect(document.activeElement).to.equal(input);
+  });
 });

--- a/test/components/TextInput_spec.js
+++ b/test/components/TextInput_spec.js
@@ -15,7 +15,7 @@ describe('TextInput', () => {
     const component = renderIntoDocument(
       <TextInput text={text} doneEditing={doneEditing}/>
     );
-    const input = component.refs.itemInput
+    const input = component.itemInput
     Simulate.keyDown(input, {key: "Enter", keyCode: 13, which: 13});
 
     expect(hasDoneEditing).to.equal(true);
@@ -28,7 +28,7 @@ describe('TextInput', () => {
     const component = renderIntoDocument(
       <TextInput text={text} cancelEditing={cancelEditing}/>
     );
-    const input = component.refs.itemInput
+    const input = component.itemInput
     Simulate.keyDown(input, {key: "Escape", keyCode: 27, which: 27});
 
     expect(hasCanceledEditing).to.equal(true);
@@ -41,7 +41,7 @@ describe('TextInput', () => {
       <TextInput text={text}/>
     );
     
-    const input = component.refs.itemInput;
+    const input = component.itemInput;
     
     expect(document.activeElement === input).to.be.true;
   });

--- a/test/components/TextInput_spec.js
+++ b/test/components/TextInput_spec.js
@@ -43,6 +43,6 @@ describe('TextInput', () => {
     
     const input = component.refs.itemInput;
     
-    expect(document.activeElement).to.equal(input);
+    expect(document.activeElement === input).to.be.true;
   });
 });

--- a/test/components/TodoItem_spec.js
+++ b/test/components/TodoItem_spec.js
@@ -88,4 +88,34 @@ describe('TodoItem', () => {
 
     expect(text).to.equal('Redux');
   });
+  
+  it('should autofocus one of TextInputs when updated with props.isEditing = true', (done) => {
+		const text = 'React';
+		
+		class Com extends React.Component {
+			constructor(props) {
+        super(props);
+        this.state = {};
+      }
+			
+			render() {
+				return (
+          <div>
+            <TodoItem text={text} isEditing={this.state.isEditing}/>
+            <TodoItem text={text} isEditing={false}/>
+          </div>
+        );
+			}
+		}
+		
+		const component = renderIntoDocument(<Com/>);
+		
+		component.setState({isEditing: true}, () => {
+			const input = scryRenderedDOMComponentsWithTag(component, 'input');
+      
+      // expect().to.equal() hangs when computing diff report
+      expect(document.activeElement === input[1]).to.be.true;
+      done();
+		});
+	});
 });


### PR DESCRIPTION
`autoFocus` triggers on first time a component mounts / input element gets inserted. Currently all `TextInput`s are rendered together with `TodoItem`s and focus gets only the last of them.

When double clicked, selected `TextInput` merely becomes visible and doesn't receive focus.

This request changes `TextInput` to be rendered conditionally when `props.isEditing===true`.
Also included are tests for autofocus of it as a standalone component and together with a sibling component (as we need to check for **not last** `TextInput` getting focus).