### PR TITLE
Set checked attribute of TodoItem from store

### DIFF
--- a/src/components/TodoItem.jsx
+++ b/src/components/TodoItem.jsx
@@ -19,7 +19,7 @@ export default class TodoItem extends React.Component {
         <input type="checkbox"
                className="toggle"
                checked={this.props.isCompleted}
-               onClick={() => this.props.toggleComplete(this.props.id)} />
+               onChange={() => this.props.toggleComplete(this.props.id)} />
         <label htmlFor="todo"
                ref="text"
                onDoubleClick={() => this.props.editItem(this.props.id)}>

--- a/src/components/TodoItem.jsx
+++ b/src/components/TodoItem.jsx
@@ -18,7 +18,7 @@ export default class TodoItem extends React.Component {
       <div className="view">
         <input type="checkbox"
                className="toggle"
-               defaultChecked={this.props.isCompleted}
+               checked={this.props.isCompleted}
                onClick={() => this.props.toggleComplete(this.props.id)} />
         <label htmlFor="todo"
                ref="text"

--- a/test/components/TodoItem_spec.js
+++ b/test/components/TodoItem_spec.js
@@ -72,7 +72,7 @@ describe('TodoItem', () => {
       <TodoItem text={text} toggleComplete={toggleComplete}/>
     );
     const checkboxes = scryRenderedDOMComponentsWithTag(component, 'input');
-    Simulate.click(checkboxes[0]);
+    Simulate.change(checkboxes[0]);
 
     expect(isChecked).to.equal(true);
   });


### PR DESCRIPTION
To better conform to one source of thruth principle and also to allow for Redux DevTools timeline controls to set/unset checkbox when appropriate.

This makes `TodoItem`a fully controlled component.
`onClick` -> `onChange` change is needed because React expects an input with controlled `checked` attribute to be controlled through `change` event. Otherwise it shows is a warning.